### PR TITLE
replace local helm commands with terraform helm_release

### DIFF
--- a/03-cilium.tf
+++ b/03-cilium.tf
@@ -1,0 +1,24 @@
+resource "helm_release" "cilium" {
+  name       = "cilium"
+  namespace  = "kube-system"
+  repository = "https://helm.cilium.io/"
+  chart      = "cilium"
+  version    = "1.9.1"
+
+  set {
+    name  = "prometheus.enabled"
+    value = "true"
+  }
+  
+  set {
+    name  = "devices"
+    value = "{eth0}"
+  }
+  
+  set {
+    name  = "hostFirewall"
+    value = "true"
+  }
+
+  depends_on = [hcloud_server.master, hcloud_network.kubenet, null_resource.init_masters, null_resource.init_workers]
+}

--- a/03-hcloud-cloud-controller-manager.tf
+++ b/03-hcloud-cloud-controller-manager.tf
@@ -1,0 +1,39 @@
+resource "helm_release" "hcloud-cloud-controller-manager" {
+  name       = "hcloud-cloud-controller-manager"
+  namespace  = "kube-system"
+  repository = "https://helm-charts.mlohr.com/"
+  chart      = "hcloud-cloud-controller-manager"
+#  version    = "1.0.4"
+
+  set {
+    name  = "manager.secret.create"
+    value = "true"
+  }
+
+  set {
+    name  = "manager.secret.hcloudApiToken"
+    value = var.hcloud_token
+  }
+
+  set {
+    name  = "manager.privateNetwork.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "manager.loadBalancers.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "manager.privateNetwork.id"
+    value = hcloud_network.kubenet.id
+  }
+
+  set {
+    name  = "manager.privateNetwork.clusterSubnet"
+    value = "10.88.0.0/16"
+  }
+
+  depends_on = [hcloud_server.master, hcloud_network.kubenet, null_resource.init_masters, null_resource.init_workers]
+}

--- a/03-hcloud-csi-driver.tf
+++ b/03-hcloud-csi-driver.tf
@@ -1,0 +1,25 @@
+provider "helm" {
+  kubernetes {
+    config_path = "secrets/admin.conf"
+  }
+}
+
+resource "helm_release" "hcloud-csi-driver" {
+  name       = "hcloud-csi-driver"
+  namespace  = "kube-system"
+  repository = "https://helm-charts.mlohr.com/"
+  chart      = "hcloud-csi-driver"
+  version    = "1.0.4"
+
+  set {
+    name  = "csiDriver.secret.create"
+    value = "true"
+  }
+
+  set {
+    name  = "csiDriver.secret.hcloudApiToken"
+    value = var.hcloud_token
+  }
+
+  depends_on = [hcloud_server.master, hcloud_network.kubenet, null_resource.init_masters, null_resource.init_workers]
+}

--- a/03-kube-post-init.tf
+++ b/03-kube-post-init.tf
@@ -1,27 +1,4 @@
 resource "null_resource" "kube-cni" {
-  provisioner "local-exec" {
-    command = "KUBECONFIG=secrets/admin.conf helm repo add cilium https://helm.cilium.io/"
-  }
-
-  provisioner "local-exec" {
-    command = "KUBECONFIG=secrets/admin.conf helm repo add mlohr https://helm-charts.mlohr.com/"
-  }
-
-  provisioner "local-exec" {
-    command = "KUBECONFIG=secrets/admin.conf helm repo update"
-  }
-
-  provisioner "local-exec" {
-    command = "KUBECONFIG=secrets/admin.conf helm install -n kube-system hcloud-csi-driver mlohr/hcloud-csi-driver --set csiDriver.secret.create=true --set csiDriver.secret.hcloudApiToken=${var.hcloud_token}"
-  }
-
-  provisioner "local-exec" {
-    command = "KUBECONFIG=secrets/admin.conf helm install -n kube-system hcloud-cloud-controller-manager mlohr/hcloud-cloud-controller-manager --set manager.secret.create=true --set manager.secret.hcloudApiToken=${var.hcloud_token} --set manager.privateNetwork.enabled=true --set manager.loadBalancers.enabled=true --set manager.privateNetwork.id=${hcloud_network.kubenet.id} --set manager.privateNetwork.clusterSubnet=10.88.0.0/16"
-  }
-
-  provisioner "local-exec" {
-    command = "KUBECONFIG=secrets/admin.conf helm install cilium cilium/cilium --version 1.9.1 --namespace kube-system --set prometheus.enabled=true --set devices='{eth0}' --set hostFirewall=true"
-  }
 
   provisioner "local-exec" {
     command = "KUBECONFIG=secrets/admin.conf kubectl apply -f ./cilium-firewall.yaml"
@@ -35,7 +12,7 @@ resource "null_resource" "kube-cni" {
     command = "KUBECONFIG=secrets/admin.conf kubectl -n monitoring create secret generic etcd-client --from-file=\"secrets/pki/etcd/ca.crt\" --from-file=\"secrets/pki/etcd/healthcheck-client.crt\" --from-file=\"secrets/pki/etcd/healthcheck-client.key\""
   }
 
-  depends_on = [hcloud_server.master, hcloud_network.kubenet, null_resource.init_masters, null_resource.init_workers]
+  depends_on = [helm_release.cilium]
 }
 
 resource "null_resource" "post_restart_masters" {


### PR DESCRIPTION
The provisioner "local-exec" should not be the preferred choice; on the one hand they require `helm` to be installed, on the other hand the occasionally failed on my system:

```
Error: Error running command 'KUBECONFIG=secrets/admin.conf helm -n kube-system status hcloud-csi-driver || helm install -n kube-system hcloud-csi-driver mlohr/hcloud-csi-driver --set csiDriver.secret.create=true --set csiDriver.secret.hcloudApiToken=REDACTED': exit status 1. Output: Error: release: not found
Error: Kubernetes cluster unreachable: Get "http://localhost:8080/version?timeout=32s": dial tcp 127.0.0.1:8080: connect: connection refused
```

With using helm_release from terraform you can observe the state and aborted installations can be repeated. Not sure about the filename layout - feel free to change.